### PR TITLE
fixed: Serialization of 'SimpleXMLElement' is not allowed

### DIFF
--- a/17.5 - 20.0/utf_8/portmone.paysystem/install/sale_payment/portmone_result/portmone_result.php
+++ b/17.5 - 20.0/utf_8/portmone.paysystem/install/sale_payment/portmone_result/portmone_result.php
@@ -64,7 +64,7 @@ if (CModule::IncludeModule('sale')) {
             "PS_STATUS_CODE"        => $answer,
             "PS_STATUS_DESCRIPTION" => ($answer != Portmone::ORDER_PAYED ? $_POST['RESULT'] : ''),
             "PS_STATUS_MESSAGE"     => ' - ',
-            "PS_SUM"                => $parseXml->orders->order->bill_amount,
+            "PS_SUM"                => (string) $parseXml->orders->order->bill_amount,
             "PS_CURRENCY"           => 'UAH',
             "PS_RESPONSE_DATE"      => date("d.m.Y H:i:s")
         );

--- a/17.5 - 20.0/win_1251/portmone.paysystem/install/sale_payment/portmone_result/portmone_result.php
+++ b/17.5 - 20.0/win_1251/portmone.paysystem/install/sale_payment/portmone_result/portmone_result.php
@@ -64,7 +64,7 @@ if (CModule::IncludeModule('sale')) {
             "PS_STATUS_CODE"        => $answer,
             "PS_STATUS_DESCRIPTION" => ($answer != Portmone::ORDER_PAYED ? $_POST['RESULT'] : ''),
             "PS_STATUS_MESSAGE"     => ' - ',
-            "PS_SUM"                => $parseXml->orders->order->bill_amount,
+            "PS_SUM"                => (string) $parseXml->orders->order->bill_amount,
             "PS_CURRENCY"           => 'UAH',
             "PS_RESPONSE_DATE"      => date("d.m.Y H:i:s")
         );


### PR DESCRIPTION
[Exception] 
Serialization of 'SimpleXMLElement' is not allowed (0)
/home/bitrix/www/bitrix/modules/pull/lib/event.php:658
#0: serialize(array)
  /home/bitrix/www/bitrix/modules/pull/lib/event.php:658
#1: Bitrix\Pull\Event::getParamsCode(array)
  /home/bitrix/www/bitrix/modules/pull/lib/event.php:148
#2: Bitrix\Pull\Event::addMessage(array, array, array)
  /home/bitrix/www/bitrix/modules/pull/lib/event.php:118
#3: Bitrix\Pull\Event::addEvent(array, array, string)
  /home/bitrix/www/bitrix/modules/pull/lib/event.php:36
#4: Bitrix\Pull\Event::add(array, array, string)
  /home/bitrix/www/bitrix/modules/pull/classes/general/pull_watch.php:238
#5: CAllPullWatch::AddToStack(string, array)
  /home/bitrix/www/bitrix/modules/crm/lib/order/payment.php:82
#6: Bitrix\Crm\Order\Payment->onAfterSave(boolean)
  /home/bitrix/www/bitrix/modules/sale/lib/payment.php:662
#7: Bitrix\Sale\Payment->save()
  /home/bitrix/www/bitrix/modules/sale/lib/paymentcollection.php:419
#8: Bitrix\Sale\PaymentCollection->save()
  /home/bitrix/www/bitrix/modules/sale/lib/order.php:2209
#9: Bitrix\Sale\Order->saveEntities()
  /home/bitrix/www/bitrix/modules/crm/lib/order/order.php:819
#10: Bitrix\Crm\Order\Order->saveEntities()
  /home/bitrix/www/bitrix/modules/sale/lib/orderbase.php:1123
#11: Bitrix\Sale\OrderBase->save()
  /home/bitrix/www/bitrix/modules/sale/lib/order.php:2321
#12: Bitrix\Sale\Order->save()
  /home/bitrix/www/bitrix/modules/sale/lib/compatible/ordercompatibility.php:1873
#13: Bitrix\Sale\Compatible\OrderCompatibility::modifyOrder(string, array)
  /home/bitrix/www/bitrix/modules/sale/lib/compatible/ordercompatibility.php:1647
#14: Bitrix\Sale\Compatible\OrderCompatibility::update(integer, array, boolean)
  /home/bitrix/www/bitrix/modules/sale/mysql/order.php:171
#15: CSaleOrder::Update(integer, array)
  /home/bitrix/www/bitrix/tools/portmone_result/portmone_result.php:75